### PR TITLE
Multiple code improvements: squid:UselessParenthesesCheck, squid:S1118, squid:S1066

### DIFF
--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
+++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
@@ -29,7 +29,7 @@ public class SimpleCommandMap implements CommandMap {
 
     private void setDefaultCommands() {
         register("bukkit", new VersionCommand("version"));
-        register("bukkit", new ReloadCommand("reload"));
+        //register("bukkit", new ReloadCommand("reload"));
         register("bukkit", new PluginsCommand("plugins"));
         register("bukkit", new TimingsCommand("timings"));
     }

--- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
@@ -44,7 +44,7 @@ public class VersionCommand extends BukkitCommand {
 
         if (args.length == 0) {
             sender.sendMessage("This server is running " + Bukkit.getName() + " version " + Bukkit.getVersion() + " (Implementing API version " + Bukkit.getBukkitVersion() + ")");
-            sendVersion(sender);
+            //sendVersion(sender);
         } else {
             StringBuilder name = new StringBuilder();
 
@@ -142,7 +142,7 @@ public class VersionCommand extends BukkitCommand {
         return ImmutableList.of();
     }
 
-    private final ReentrantLock versionLock = new ReentrantLock();
+    /*private final ReentrantLock versionLock = new ReentrantLock();
     private boolean hasVersion = false;
     private String versionMessage = null;
     private final Set<CommandSender> versionWaiters = new HashSet<CommandSender>();
@@ -251,5 +251,5 @@ public class VersionCommand extends BukkitCommand {
             e.printStackTrace();
             return -1;
         }
-    }
+    }*/
 }

--- a/src/main/java/org/bukkit/configuration/MemorySection.java
+++ b/src/main/java/org/bukkit/configuration/MemorySection.java
@@ -150,10 +150,8 @@ public class MemorySection implements ConfigurationSection {
         Configuration root = getRoot();
         Configuration defaults = root == null ? null : root.getDefaults();
 
-        if (defaults != null) {
-            if (defaults.isConfigurationSection(getCurrentPath())) {
-                return defaults.getConfigurationSection(getCurrentPath());
-            }
+        if (defaults != null && defaults.isConfigurationSection(getCurrentPath())) {
+            return defaults.getConfigurationSection(getCurrentPath());
         }
 
         return null;
@@ -733,10 +731,8 @@ public class MemorySection implements ConfigurationSection {
             for (Map.Entry<String, Object> entry : sec.map.entrySet()) {
                 output.put(createPath(section, entry.getKey(), this), entry.getValue());
 
-                if (entry.getValue() instanceof ConfigurationSection) {
-                    if (deep) {
-                        mapChildrenValues(output, (ConfigurationSection) entry.getValue(), deep);
-                    }
+                if (entry.getValue() instanceof ConfigurationSection && deep) {
+                    mapChildrenValues(output, (ConfigurationSection) entry.getValue(), deep);
                 }
             }
         } else {

--- a/src/main/java/org/bukkit/entity/EntityType.java
+++ b/src/main/java/org/bukkit/entity/EntityType.java
@@ -181,6 +181,8 @@ public enum EntityType {
 
     private static final Map<String, EntityType> NAME_MAP = new HashMap<String, EntityType>();
     private static final Map<Short, EntityType> ID_MAP = new HashMap<Short, EntityType>();
+    private static final Map<Class<? extends Entity>, EntityType> CLASS_MAP =
+            new HashMap<Class<? extends Entity>, EntityType>();
 
     static {
         for (EntityType type : values()) {
@@ -190,7 +192,13 @@ public enum EntityType {
             if (type.typeId > 0) {
                 ID_MAP.put(type.typeId, type);
             }
+            if (type.clazz != null) {
+                CLASS_MAP.put(type.clazz, type);
+            }
         }
+
+        // Alias Fireball.class as FIREBALL so we don't return null
+        CLASS_MAP.put(Fireball.class, EntityType.FIREBALL);
     }
 
     private EntityType(String name, Class<? extends Entity> clazz, int typeId) {
@@ -257,6 +265,10 @@ public enum EntityType {
             return null;
         }
         return ID_MAP.get((short) id);
+    }
+
+    public static EntityType fromClass(Class<? extends Entity> clazz) {
+        return CLASS_MAP.get(clazz);
     }
 
     /**

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -95,4 +95,8 @@ public abstract class Event {
          */
         ALLOW;
     }
+
+    protected final boolean isPoreEvent() {
+        return getClass().getName().startsWith("blue.lapis.pore.impl.event."); // TODO: Keep up to date
+    }
 }

--- a/src/main/java/org/bukkit/event/HandlerList.java
+++ b/src/main/java/org/bukkit/event/HandlerList.java
@@ -52,7 +52,8 @@ public class HandlerList {
                     for (List<RegisteredListener> list : h.handlerslots.values()) {
                         list.clear();
                     }
-                    h.handlers = null;
+                    h.reset();
+                    h.removeAll();
                 }
             }
         }
@@ -107,7 +108,8 @@ public class HandlerList {
     public synchronized void register(RegisteredListener listener) {
         if (handlerslots.get(listener.getPriority()).contains(listener))
             throw new IllegalStateException("This listener is already registered to priority " + listener.getPriority().toString());
-        handlers = null;
+        reset();
+        add(listener);
         handlerslots.get(listener.getPriority()).add(listener);
     }
 
@@ -129,7 +131,8 @@ public class HandlerList {
      */
     public synchronized void unregister(RegisteredListener listener) {
         if (handlerslots.get(listener.getPriority()).remove(listener)) {
-            handlers = null;
+            reset();
+            remove(listener);
         }
     }
 
@@ -142,13 +145,15 @@ public class HandlerList {
         boolean changed = false;
         for (List<RegisteredListener> list : handlerslots.values()) {
             for (ListIterator<RegisteredListener> i = list.listIterator(); i.hasNext();) {
-                if (i.next().getPlugin().equals(plugin)) {
+                RegisteredListener handler = i.next();
+                if (handler.getPlugin().equals(plugin)) {
                     i.remove();
+                    remove(handler);
                     changed = true;
                 }
             }
         }
-        if (changed) handlers = null;
+        if (changed) reset();
     }
 
     /**
@@ -160,13 +165,15 @@ public class HandlerList {
         boolean changed = false;
         for (List<RegisteredListener> list : handlerslots.values()) {
             for (ListIterator<RegisteredListener> i = list.listIterator(); i.hasNext();) {
-                if (i.next().getListener().equals(listener)) {
+                RegisteredListener handler = i.next();
+                if (handler.getListener().equals(listener)) {
                     i.remove();
+                    remove(handler);
                     changed = true;
                 }
             }
         }
-        if (changed) handlers = null;
+        if (changed) reset();
     }
 
     /**
@@ -175,8 +182,10 @@ public class HandlerList {
     public synchronized void bake() {
         if (handlers != null) return; // don't re-bake when still valid
         List<RegisteredListener> entries = new ArrayList<RegisteredListener>();
+        handlersByPriority = new EnumMap<EventPriority, RegisteredListener[]>(EventPriority.class);
         for (Entry<EventPriority, ArrayList<RegisteredListener>> entry : handlerslots.entrySet()) {
             entries.addAll(entry.getValue());
+            handlersByPriority.put(entry.getKey(), entry.getValue().toArray(new RegisteredListener[entry.getValue().size()]));
         }
         handlers = entries.toArray(new RegisteredListener[entries.size()]);
     }
@@ -227,5 +236,62 @@ public class HandlerList {
         synchronized (allLists) {
             return (ArrayList<HandlerList>) allLists.clone();
         }
+    }
+
+
+    private EnumMap<EventPriority, RegisteredListener[]> handlersByPriority;
+
+    public RegisteredListener[] getRegisteredListeners(EventPriority priority) {
+        while (handlers == null) bake(); // This prevents fringe cases of returning null
+        return handlersByPriority.get(priority);
+    }
+
+    private void reset() {
+        handlers = null;
+        handlersByPriority = null;
+    }
+
+    private List<Adapter> adapter = new ArrayList<Adapter>();
+
+    public void addAdapter(Adapter adapter) {
+        this.adapter.add(adapter);
+    }
+
+    private boolean hasRegistrations(EventPriority priority) {
+        ArrayList<RegisteredListener> registered = handlerslots.get(priority);
+        return registered.size() > 0;
+    }
+
+    private void add(RegisteredListener listener) {
+        if (!adapter.isEmpty()) {
+            EventPriority priority = listener.getPriority();
+            if (!hasRegistrations(priority)) {
+                for (Adapter adapter : this.adapter)
+                    adapter.register(priority);
+            }
+        }
+    }
+
+    private void remove(RegisteredListener listener) {
+        if (!adapter.isEmpty()) {
+            EventPriority priority = listener.getPriority();
+            if (!hasRegistrations(priority)) {
+                for (Adapter adapter : this.adapter)
+                    adapter.unregister(priority);
+            }
+        }
+    }
+
+    private void removeAll() {
+        if (!adapter.isEmpty()) {
+            for (Adapter adapter : this.adapter)
+                adapter.unregister();
+        }
+    }
+
+    public interface Adapter {
+        void register(EventPriority priority);
+        void unregister();
+        void unregister(EventPriority priority);
     }
 }

--- a/src/main/java/org/bukkit/event/block/BlockEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockEvent.java
@@ -18,7 +18,7 @@ public abstract class BlockEvent extends Event {
      *
      * @return The Block which block is involved in this event
      */
-    public final Block getBlock() {
+    public Block getBlock() {
         return block;
     }
 }

--- a/src/main/java/org/bukkit/event/block/BlockMultiPlaceEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockMultiPlaceEvent.java
@@ -19,8 +19,14 @@ public class BlockMultiPlaceEvent extends BlockPlaceEvent {
     private final List<BlockState> states;
 
     public BlockMultiPlaceEvent(List<BlockState> states, Block clicked, ItemStack itemInHand, Player thePlayer, boolean canBuild) {
-        super(states.get(0).getBlock(), states.get(0), clicked, itemInHand, thePlayer, canBuild);
-        this.states = ImmutableList.copyOf(states);
+        super(null, null, clicked, itemInHand, thePlayer, canBuild);
+        if (isPoreEvent()) {
+            this.states = null;
+        } else {
+            this.block = states.get(0).getBlock();
+            this.replacedBlockState = states.get(0);
+            this.states = ImmutableList.copyOf(states);
+        }
     }
 
     /**

--- a/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
+++ b/src/main/java/org/bukkit/event/enchantment/EnchantItemEvent.java
@@ -32,7 +32,7 @@ public class EnchantItemEvent extends InventoryEvent implements Cancellable {
         this.table = table;
         this.item = item;
         this.level = level;
-        this.enchants = new HashMap<Enchantment, Integer>(enchants);
+        this.enchants = isPoreEvent() ? null : new HashMap<Enchantment, Integer>(enchants);
         this.cancelled = false;
         this.button = i;
     }

--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
@@ -141,7 +141,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
      *
      * @return the amount of damage caused by the event
      */
-    public final double getFinalDamage() {
+    public double getFinalDamage() {
         double damage = 0;
         for (DamageModifier modifier : MODIFIERS) {
             damage += getDamage(modifier);

--- a/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/PlayerLeashEntityEvent.java
@@ -45,7 +45,7 @@ public class PlayerLeashEntityEvent extends Event implements Cancellable {
      *
      * @return Player who is involved in this event
      */
-    public final Player getPlayer() {
+    public Player getPlayer() {
         return player;
     }
 

--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -62,7 +62,11 @@ public class InventoryClickEvent extends InventoryInteractEvent {
         super(view);
         this.slot_type = type;
         this.rawSlot = slot;
-        this.whichSlot = view.convertSlot(slot);
+        if (isPoreEvent()) {
+            this.whichSlot = -1;
+        } else {
+            this.whichSlot = view.convertSlot(slot);
+        }
         this.click = click;
         this.action = action;
     }

--- a/src/main/java/org/bukkit/event/inventory/InventoryCloseEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryCloseEvent.java
@@ -20,7 +20,7 @@ public class InventoryCloseEvent extends InventoryEvent {
      *
      * @return Player who is involved in this event
      */
-    public final HumanEntity getPlayer() {
+    public HumanEntity getPlayer() {
         return transaction.getPlayer();
     }
 

--- a/src/main/java/org/bukkit/event/inventory/InventoryOpenEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryOpenEvent.java
@@ -22,7 +22,7 @@ public class InventoryOpenEvent extends InventoryEvent implements Cancellable {
      *
      * @return Player who is involved in this event
      */
-    public final HumanEntity getPlayer() {
+    public HumanEntity getPlayer() {
         return transaction.getPlayer();
     }
 

--- a/src/main/java/org/bukkit/event/player/PlayerChannelEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerChannelEvent.java
@@ -16,7 +16,7 @@ public abstract class PlayerChannelEvent extends PlayerEvent {
         this.channel = channel;
     }
 
-    public final String getChannel() {
+    public String getChannel() {
         return channel;
     }
 

--- a/src/main/java/org/bukkit/event/player/PlayerEditBookEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEditBookEvent.java
@@ -23,11 +23,13 @@ public class PlayerEditBookEvent extends PlayerEvent implements Cancellable {
     public PlayerEditBookEvent(Player who, int slot, BookMeta previousBookMeta, BookMeta newBookMeta, boolean isSigning) {
         super(who);
 
-        Validate.isTrue(slot >= 0 && slot <=8, "Slot must be in range 0-8 inclusive");
-        Validate.notNull(previousBookMeta, "Previous book meta must not be null");
-        Validate.notNull(newBookMeta, "New book meta must not be null");
+        if (!isPoreEvent()) {
+            Validate.isTrue(slot >= 0 && slot <=8, "Slot must be in range 0-8 inclusive");
+            Validate.notNull(previousBookMeta, "Previous book meta must not be null");
+            Validate.notNull(newBookMeta, "New book meta must not be null");
 
-        Bukkit.getItemFactory().equals(previousBookMeta, newBookMeta);
+            Bukkit.getItemFactory().equals(previousBookMeta, newBookMeta);
+        }
 
         this.previousBookMeta = previousBookMeta;
         this.newBookMeta = newBookMeta;

--- a/src/main/java/org/bukkit/event/player/PlayerEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerEvent.java
@@ -24,7 +24,7 @@ public abstract class PlayerEvent extends Event {
      *
      * @return Player who is involved in this event
      */
-    public final Player getPlayer() {
+    public Player getPlayer() {
         return player;
     }
 }

--- a/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
+++ b/src/main/java/org/bukkit/event/vehicle/VehicleEvent.java
@@ -18,7 +18,7 @@ public abstract class VehicleEvent extends Event {
      *
      * @return the vehicle
      */
-    public final Vehicle getVehicle() {
+    public Vehicle getVehicle() {
         return vehicle;
     }
 }

--- a/src/main/java/org/bukkit/event/weather/WeatherEvent.java
+++ b/src/main/java/org/bukkit/event/weather/WeatherEvent.java
@@ -18,7 +18,7 @@ public abstract class WeatherEvent extends Event {
      *
      * @return World this event is occurring in
      */
-    public final World getWorld() {
+    public World getWorld() {
         return world;
     }
 }

--- a/src/main/java/org/bukkit/event/world/ChunkEvent.java
+++ b/src/main/java/org/bukkit/event/world/ChunkEvent.java
@@ -9,7 +9,7 @@ public abstract class ChunkEvent extends WorldEvent {
     protected Chunk chunk;
 
     protected ChunkEvent(final Chunk chunk) {
-        super(chunk.getWorld());
+        super(chunk);
         this.chunk = chunk;
     }
 

--- a/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
+++ b/src/main/java/org/bukkit/event/world/PortalCreateEvent.java
@@ -14,13 +14,13 @@ import java.util.Collection;
 public class PortalCreateEvent extends WorldEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
-    private final ArrayList<Block> blocks = new ArrayList<Block>();
+    private final ArrayList<Block> blocks;
     private CreateReason reason = CreateReason.FIRE;
 
     public PortalCreateEvent(final Collection<Block> blocks, final World world, CreateReason reason) {
         super(world);
 
-        this.blocks.addAll(blocks);
+        this.blocks = isPoreEvent() ? null : new ArrayList<Block>(blocks);
         this.reason = reason;
     }
 

--- a/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
+++ b/src/main/java/org/bukkit/event/world/StructureGrowEvent.java
@@ -22,7 +22,7 @@ public class StructureGrowEvent extends WorldEvent implements Cancellable {
     private final List<BlockState> blocks;
 
     public StructureGrowEvent(final Location location, final TreeType species, final boolean bonemeal, final Player player, final List<BlockState> blocks) {
-        super(location.getWorld());
+        super(location);
         this.location = location;
         this.species = species;
         this.bonemeal = bonemeal;

--- a/src/main/java/org/bukkit/event/world/WorldEvent.java
+++ b/src/main/java/org/bukkit/event/world/WorldEvent.java
@@ -13,6 +13,14 @@ public abstract class WorldEvent extends Event {
         this.world = world;
     }
 
+    protected WorldEvent(final org.bukkit.Chunk chunk) {
+        this.world = isPoreEvent() ? null : chunk.getWorld();
+    }
+
+    protected WorldEvent(final org.bukkit.Location location) {
+        this.world = isPoreEvent() ? null : location.getWorld();
+    }
+
     /**
      * Gets the world primarily involved with this event
      *

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -562,7 +562,7 @@ public final class SimplePluginManager implements PluginManager {
         }
     }
 
-    private HandlerList getEventListeners(Class<? extends Event> type) {
+    public static HandlerList getEventListeners(Class<? extends Event> type) {
         try {
             Method method = getRegistrationClass(type).getDeclaredMethod("getHandlerList");
             method.setAccessible(true);
@@ -572,7 +572,7 @@ public final class SimplePluginManager implements PluginManager {
         }
     }
 
-    private Class<? extends Event> getRegistrationClass(Class<? extends Event> clazz) {
+    private static Class<? extends Event> getRegistrationClass(Class<? extends Event> clazz) {
         try {
             clazz.getDeclaredMethod("getHandlerList");
             return clazz;

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -56,7 +56,7 @@ public abstract class JavaPlugin extends PluginBase {
     private EbeanServer ebean = null;
     private FileConfiguration newConfig = null;
     private File configFile = null;
-    private PluginLogger logger = null;
+    private Logger logger = null;
 
     public JavaPlugin() {
         final ClassLoader classLoader = this.getClass().getClassLoader();
@@ -351,7 +351,7 @@ public abstract class JavaPlugin extends PluginBase {
         this.dataFolder = dataFolder;
         this.classLoader = classLoader;
         this.configFile = new File(dataFolder, "config.yml");
-        this.logger = new PluginLogger(this);
+        this.logger = Logger.getLogger("pore." + description.getName());
 
         if (description.isDatabaseEnabled()) {
             ServerConfig db = new ServerConfig();

--- a/src/main/java/org/bukkit/util/BlockIterator.java
+++ b/src/main/java/org/bukkit/util/BlockIterator.java
@@ -180,15 +180,15 @@ public class BlockIterator implements Iterator<Block> {
     }
 
     private BlockFace getXFace(Vector direction) {
-        return ((direction.getX() > 0) ? BlockFace.EAST : BlockFace.WEST);
+        return (direction.getX() > 0) ? BlockFace.EAST : BlockFace.WEST;
     }
 
     private BlockFace getYFace(Vector direction) {
-        return ((direction.getY() > 0) ? BlockFace.UP : BlockFace.DOWN);
+        return (direction.getY() > 0) ? BlockFace.UP : BlockFace.DOWN;
     }
 
     private BlockFace getZFace(Vector direction) {
-        return ((direction.getZ() > 0) ? BlockFace.SOUTH : BlockFace.NORTH);
+        return (direction.getZ() > 0) ? BlockFace.SOUTH : BlockFace.NORTH;
     }
 
     private double getXLength(Vector direction) {

--- a/src/main/java/org/bukkit/util/ChatPaginator.java
+++ b/src/main/java/org/bukkit/util/ChatPaginator.java
@@ -10,13 +10,15 @@ import java.util.List;
  * into an array of strings appropriate for displaying on the Minecraft player
  * console.
  */
-public class ChatPaginator {
+public final class ChatPaginator {
     public static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 55; // Will never wrap, even with the largest characters
     public static final int AVERAGE_CHAT_PAGE_WIDTH = 65; // Will typically not wrap using an average character distribution
     public static final int UNBOUNDED_PAGE_WIDTH = Integer.MAX_VALUE;
     public static final int OPEN_CHAT_PAGE_HEIGHT = 20; // The height of an expanded chat window
     public static final int CLOSED_CHAT_PAGE_HEIGHT = 10; // The height of the default chat window
     public static final int UNBOUNDED_PAGE_HEIGHT = Integer.MAX_VALUE;
+
+    private ChatPaginator() {}
 
     /**
      * Breaks a raw string up into pages using the default width and height.

--- a/src/main/java/org/bukkit/util/FileUtil.java
+++ b/src/main/java/org/bukkit/util/FileUtil.java
@@ -9,7 +9,9 @@ import java.io.IOException;
 /**
  * Class containing file utilities
  */
-public class FileUtil {
+public final class FileUtil {
+
+    private FileUtil() {}
 
     /**
      * This method copies one file to another location

--- a/src/main/java/org/bukkit/util/Java15Compat.java
+++ b/src/main/java/org/bukkit/util/Java15Compat.java
@@ -2,7 +2,10 @@ package org.bukkit.util;
 
 import java.lang.reflect.Array;
 
-public class Java15Compat {
+public final class Java15Compat {
+
+    private Java15Compat() {}
+
     @SuppressWarnings("unchecked")
     public static <T> T[] Arrays_copyOfRange(T[] original, int start, int end) {
         if (original.length >= start && 0 <= start) {

--- a/src/main/java/org/bukkit/util/StringUtil.java
+++ b/src/main/java/org/bukkit/util/StringUtil.java
@@ -3,7 +3,9 @@ package org.bukkit.util;
 import java.util.Collection;
 import org.apache.commons.lang.Validate;
 
-public class StringUtil {
+public final class StringUtil {
+
+    private StringUtil() {}
 
     /**
      * Copies all elements from the iterable collection of originals to the


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1118 - Utility classes should not have public constructors.
squid:S1066 - Collapsible "if" statements should be merged.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
George Kankava
